### PR TITLE
[1.19.x] Add Data Generators for Fabric and Quilt Loaders

### DIFF
--- a/fabric/fabric-groovy/build.gradle.kts
+++ b/fabric/fabric-groovy/build.gradle.kts
@@ -49,6 +49,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Fabric Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Fabric Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Localizations.groovy
+++ b/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Localizations.groovy
@@ -1,0 +1,32 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an {@code en_us} localization for the mod.
+ */
+final class Localizations extends FabricLanguageProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    Localizations(FabricDataGenerator gen) {
+        super(gen)
+    }
+
+    @Override
+    void generateTranslations(TranslationBuilder builder) {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash")
+    }
+}

--- a/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Models.groovy
+++ b/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Models.groovy
@@ -1,0 +1,38 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.BlockModelGenerators
+import net.minecraft.data.models.ItemModelGenerators
+import net.minecraft.data.models.model.ModelTemplates
+
+/**
+ * A data provider which generates models for this mod.
+ */
+final class Models extends FabricModelProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    Models(FabricDataGenerator gen) {
+        super(gen)
+    }
+
+    @Override
+    void generateBlockStateModels(BlockModelGenerators generators) {}
+
+    @Override
+    void generateItemModels(ItemModelGenerators generators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.groovy
+++ b/fabric/fabric-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.groovy
@@ -1,0 +1,38 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+
+import java.util.function.Function
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within {@code entrypoints.fabric-datagen}. Any data entry point
+ * must implement {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
+ */
+final class MultilingualExamplesData implements DataGeneratorEntrypoint {
+
+    @Override
+    void onInitializeDataGenerator(FabricDataGenerator gen) {
+        // Add providers
+        gen.addProvider(new Function<FabricDataGenerator, Localizations>() {
+            @Override
+            Localizations apply(FabricDataGenerator generator) {
+                return new Localizations(generator)
+            }
+        })
+        gen.addProvider(new Function<FabricDataGenerator, Models>() {
+            @Override
+            Models apply(FabricDataGenerator generator) {
+                return new Models(generator)
+            }
+        })
+    }
+}

--- a/fabric/fabric-groovy/src/main/resources/fabric.mod.json
+++ b/fabric/fabric-groovy/src/main/resources/fabric.mod.json
@@ -27,6 +27,11 @@
             {
                 "value": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
             }
+        ],
+        "fabric-datagen": [
+            {
+                "value": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
+            }
         ]
     },
 

--- a/fabric/fabric-java/build.gradle.kts
+++ b/fabric/fabric-java/build.gradle.kts
@@ -47,6 +47,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Fabric Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Fabric Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
@@ -1,0 +1,26 @@
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider;
+
+/**
+ * A data provider which generates an {@code en_us} localization for the mod.
+ */
+public final class Localizations extends FabricLanguageProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    public Localizations(final FabricDataGenerator gen) {
+        super(gen);
+    }
+
+    @Override
+    public void generateTranslations(final TranslationBuilder builder) {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash");
+    }
+}

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
@@ -1,3 +1,9 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 package net.ashwork.mc.multilingualexamples.data;
 
 import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
@@ -1,3 +1,9 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 package net.ashwork.mc.multilingualexamples.data;
 
 import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
@@ -1,0 +1,32 @@
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider;
+import net.minecraft.data.models.BlockModelGenerators;
+import net.minecraft.data.models.ItemModelGenerators;
+import net.minecraft.data.models.model.ModelTemplates;
+
+/**
+ * A data provider which generates models for this mod.
+ */
+public final class Models extends FabricModelProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    public Models(FabricDataGenerator gen) {
+        super(gen);
+    }
+
+    @Override
+    public void generateBlockStateModels(BlockModelGenerators generators) {}
+
+    @Override
+    public void generateItemModels(ItemModelGenerators generators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM);
+    }
+}

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
@@ -1,0 +1,20 @@
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within {@code entrypoints.fabric-datagen}. Any data entry point
+ * must implement {@link DataGeneratorEntrypoint}.
+ */
+public final class MultilingualExamplesData implements DataGeneratorEntrypoint {
+
+    @Override
+    public void onInitializeDataGenerator(final FabricDataGenerator gen) {
+        // Add providers
+        gen.addProvider(Localizations::new);
+        gen.addProvider(Models::new);
+    }
+}

--- a/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
+++ b/fabric/fabric-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
@@ -1,3 +1,9 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 package net.ashwork.mc.multilingualexamples.data;
 
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;

--- a/fabric/fabric-java/src/main/resources/fabric.mod.json
+++ b/fabric/fabric-java/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
         ],
         "client": [
             "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
+        ],
+        "fabric-datagen": [
+            "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
         ]
     },
 

--- a/fabric/fabric-kotlin/build.gradle.kts
+++ b/fabric/fabric-kotlin/build.gradle.kts
@@ -49,6 +49,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Fabric Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Fabric Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Localizations.kt
+++ b/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Localizations.kt
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ASH
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an 'en_us' localization for the mod.
+ *
+ * @param gen the generator being written to
+ */
+class Localizations(gen: FabricDataGenerator): FabricLanguageProvider(gen) {
+
+    override fun generateTranslations(builder: TranslationBuilder) {
+        // Add items
+        builder.add(ASH, "Ash")
+    }
+}

--- a/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Models.kt
+++ b/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Models.kt
@@ -1,0 +1,29 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ASH
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.BlockModelGenerators
+import net.minecraft.data.models.ItemModelGenerators
+import net.minecraft.data.models.model.ModelTemplates
+
+/**
+ * A data provider which generates models for this mod.
+ *
+ * @param gen the generator being written to
+ */
+class Models(gen: FabricDataGenerator): FabricModelProvider(gen) {
+
+    override fun generateBlockStateModels(generators: BlockModelGenerators) {}
+
+    override fun generateItemModels(generators: ItemModelGenerators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.kt
+++ b/fabric/fabric-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.kt
@@ -1,0 +1,25 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within 'entrypoints.fabric-datagen'. Any data entry point must
+ * implement [DataGeneratorEntrypoint].
+ */
+internal object MultilingualExamplesData: DataGeneratorEntrypoint {
+
+    override fun onInitializeDataGenerator(gen: FabricDataGenerator) {
+        // Add providers
+        gen.addProvider(::Localizations)
+        gen.addProvider(::Models)
+    }
+}

--- a/fabric/fabric-kotlin/src/main/resources/fabric.mod.json
+++ b/fabric/fabric-kotlin/src/main/resources/fabric.mod.json
@@ -29,6 +29,12 @@
                 "adapter": "kotlin",
                 "value": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
             }
+        ],
+        "fabric-datagen": [
+            {
+                "adapter": "kotlin",
+                "value": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
+            }
         ]
     },
 

--- a/fabric/fabric-scala/build.gradle.kts
+++ b/fabric/fabric-scala/build.gradle.kts
@@ -50,6 +50,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Fabric Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Fabric Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/fabric/fabric-scala/src/main/resources/fabric.mod.json
+++ b/fabric/fabric-scala/src/main/resources/fabric.mod.json
@@ -29,6 +29,12 @@
                 "adapter": "scala",
                 "value": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
             }
+        ],
+        "fabric-datagen": [
+            {
+                "adapter": "scala",
+                "value": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
+            }
         ]
     },
 

--- a/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Localizations.scala
+++ b/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Localizations.scala
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an 'en_us' localization for the mod.
+ *
+ * @param gen the generator being written to
+ */
+class Localizations(gen: FabricDataGenerator) extends FabricLanguageProvider(gen) {
+
+    override def generateTranslations(builder: FabricLanguageProvider.TranslationBuilder): Unit = {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash")
+    }
+}

--- a/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Models.scala
+++ b/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Models.scala
@@ -1,0 +1,28 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.model.ModelTemplates
+import net.minecraft.data.models.{BlockModelGenerators, ItemModelGenerators}
+
+/**
+ * A data provider which generates models for this mod.
+ *
+ * @param gen the generator being written to
+ */
+class Models(gen: FabricDataGenerator) extends FabricModelProvider(gen) {
+
+    override def generateBlockStateModels(generators: BlockModelGenerators): Unit = {}
+
+    override def generateItemModels(generators: ItemModelGenerators): Unit = {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.scala
+++ b/fabric/fabric-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.scala
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.{DataGeneratorEntrypoint, FabricDataGenerator}
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within 'entrypoints.fabric-datagen'. Any data entry point must
+ * implement [[DataGeneratorEntrypoint]].
+ */
+object MultilingualExamplesData extends DataGeneratorEntrypoint {
+
+    override def onInitializeDataGenerator(gen: FabricDataGenerator): Unit = {
+        // Add providers
+        gen.addProvider(new Localizations(_))
+        gen.addProvider(new Models(_))
+    }
+}

--- a/quilt/quilt-groovy/build.gradle.kts
+++ b/quilt/quilt-groovy/build.gradle.kts
@@ -49,6 +49,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Quilt Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Quilt Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Localizations.groovy
+++ b/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Localizations.groovy
@@ -1,0 +1,32 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an {@code en_us} localization for the mod.
+ */
+final class Localizations extends FabricLanguageProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    Localizations(FabricDataGenerator gen) {
+        super(gen)
+    }
+
+    @Override
+    void generateTranslations(TranslationBuilder builder) {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash")
+    }
+}

--- a/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Models.groovy
+++ b/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/Models.groovy
@@ -1,0 +1,38 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.BlockModelGenerators
+import net.minecraft.data.models.ItemModelGenerators
+import net.minecraft.data.models.model.ModelTemplates
+
+/**
+ * A data provider which generates models for this mod.
+ */
+final class Models extends FabricModelProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    Models(FabricDataGenerator gen) {
+        super(gen)
+    }
+
+    @Override
+    void generateBlockStateModels(BlockModelGenerators generators) {}
+
+    @Override
+    void generateItemModels(ItemModelGenerators generators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.groovy
+++ b/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.groovy
@@ -1,0 +1,38 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+
+import java.util.function.Function
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within {@code entrypoints.fabric-datagen}. Any data entry point
+ * must implement {@link net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint}.
+ */
+final class MultilingualExamplesData implements DataGeneratorEntrypoint {
+
+    @Override
+    void onInitializeDataGenerator(FabricDataGenerator gen) {
+        // Add providers
+        gen.addProvider(new Function<FabricDataGenerator, Localizations>() {
+            @Override
+            Localizations apply(FabricDataGenerator generator) {
+                return new Localizations(generator)
+            }
+        })
+        gen.addProvider(new Function<FabricDataGenerator, Models>() {
+            @Override
+            Models apply(FabricDataGenerator generator) {
+                return new Models(generator)
+            }
+        })
+    }
+}

--- a/quilt/quilt-groovy/src/main/resources/quilt.mod.json
+++ b/quilt/quilt-groovy/src/main/resources/quilt.mod.json
@@ -22,7 +22,8 @@
 
         "entrypoints": {
             "init": "net.ashwork.mc.multilingualexamples.MultilingualExamples",
-            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
+            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient",
+            "fabric-datagen": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
         },
         "intermediate_mappings": "net.fabricmc:intermediary",
 

--- a/quilt/quilt-java/build.gradle.kts
+++ b/quilt/quilt-java/build.gradle.kts
@@ -47,6 +47,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Quilt Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Quilt Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Localizations.java
@@ -1,0 +1,32 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider;
+
+/**
+ * A data provider which generates an {@code en_us} localization for the mod.
+ */
+public final class Localizations extends FabricLanguageProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    public Localizations(final FabricDataGenerator gen) {
+        super(gen);
+    }
+
+    @Override
+    public void generateTranslations(final TranslationBuilder builder) {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash");
+    }
+}

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/Models.java
@@ -1,0 +1,38 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider;
+import net.minecraft.data.models.BlockModelGenerators;
+import net.minecraft.data.models.ItemModelGenerators;
+import net.minecraft.data.models.model.ModelTemplates;
+
+/**
+ * A data provider which generates models for this mod.
+ */
+public final class Models extends FabricModelProvider {
+
+    /**
+     * A simple constructor.
+     *
+     * @param gen the generator being written to
+     */
+    public Models(FabricDataGenerator gen) {
+        super(gen);
+    }
+
+    @Override
+    public void generateBlockStateModels(BlockModelGenerators generators) {}
+
+    @Override
+    public void generateItemModels(ItemModelGenerators generators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM);
+    }
+}

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.java
@@ -1,0 +1,26 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data;
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within {@code entrypoints.fabric-datagen}. Any data entry point
+ * must implement {@link DataGeneratorEntrypoint}.
+ */
+public final class MultilingualExamplesData implements DataGeneratorEntrypoint {
+
+    @Override
+    public void onInitializeDataGenerator(final FabricDataGenerator gen) {
+        // Add providers
+        gen.addProvider(Localizations::new);
+        gen.addProvider(Models::new);
+    }
+}

--- a/quilt/quilt-java/src/main/resources/quilt.mod.json
+++ b/quilt/quilt-java/src/main/resources/quilt.mod.json
@@ -22,7 +22,8 @@
 
         "entrypoints": {
             "init": "net.ashwork.mc.multilingualexamples.MultilingualExamples",
-            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
+            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient",
+            "fabric-datagen": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
         },
         "intermediate_mappings": "net.fabricmc:intermediary",
 

--- a/quilt/quilt-kotlin/build.gradle.kts
+++ b/quilt/quilt-kotlin/build.gradle.kts
@@ -49,6 +49,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Quilt Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Quilt Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Localizations.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Localizations.kt
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ASH
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an 'en_us' localization for the mod.
+ *
+ * @param gen the generator being written to
+ */
+class Localizations(gen: FabricDataGenerator): FabricLanguageProvider(gen) {
+
+    override fun generateTranslations(builder: TranslationBuilder) {
+        // Add items
+        builder.add(ASH, "Ash")
+    }
+}

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Models.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/Models.kt
@@ -1,0 +1,29 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ASH
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.BlockModelGenerators
+import net.minecraft.data.models.ItemModelGenerators
+import net.minecraft.data.models.model.ModelTemplates
+
+/**
+ * A data provider which generates models for this mod.
+ *
+ * @param gen the generator being written to
+ */
+class Models(gen: FabricDataGenerator): FabricModelProvider(gen) {
+
+    override fun generateBlockStateModels(generators: BlockModelGenerators) {}
+
+    override fun generateItemModels(generators: ItemModelGenerators) {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.kt
@@ -1,0 +1,25 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within 'entrypoints.fabric-datagen'. Any data entry point must
+ * implement [DataGeneratorEntrypoint].
+ */
+internal class MultilingualExamplesData: DataGeneratorEntrypoint {
+
+    override fun onInitializeDataGenerator(gen: FabricDataGenerator) {
+        // Add providers
+        gen.addProvider(::Localizations)
+        gen.addProvider(::Models)
+    }
+}

--- a/quilt/quilt-kotlin/src/main/resources/quilt.mod.json
+++ b/quilt/quilt-kotlin/src/main/resources/quilt.mod.json
@@ -22,7 +22,8 @@
 
         "entrypoints": {
             "init": "net.ashwork.mc.multilingualexamples.MultilingualExamples",
-            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
+            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient",
+            "fabric-datagen": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
         },
         "intermediate_mappings": "net.fabricmc:intermediary",
 

--- a/quilt/quilt-scala/build.gradle.kts
+++ b/quilt/quilt-scala/build.gradle.kts
@@ -49,6 +49,16 @@ loom.runs {
         configName = "${languageId.capitalize()} Quilt Server"
         runDir("../run/server")
     }
+    create("data") {
+        server()
+        configName = "${languageId.capitalize()} Quilt Data"
+        runDir("../run/data")
+        vmArgs(
+            "-Dfabric-api.datagen",
+            "-Dfabric-api.datagen.output-dir=${generatedResources}",
+            "-Dfabric-api.datagen.strict-validation"
+        )
+    }
 
     all {
         ideConfigGenerated(true)

--- a/quilt/quilt-scala/src/main/resources/quilt.mod.json
+++ b/quilt/quilt-scala/src/main/resources/quilt.mod.json
@@ -22,7 +22,8 @@
 
         "entrypoints": {
             "init": "net.ashwork.mc.multilingualexamples.MultilingualExamples",
-            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient"
+            "client_init": "net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient",
+            "fabric-datagen": "net.ashwork.mc.multilingualexamples.data.MultilingualExamplesData"
         },
         "intermediate_mappings": "net.fabricmc:intermediary",
 

--- a/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Localizations.scala
+++ b/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Localizations.scala
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
+
+/**
+ * A data provider which generates an 'en_us' localization for the mod.
+ *
+ * @param gen the generator being written to
+ */
+class Localizations(gen: FabricDataGenerator) extends FabricLanguageProvider(gen) {
+
+    override def generateTranslations(builder: FabricLanguageProvider.TranslationBuilder): Unit = {
+        // Add items
+        builder.add(ItemRegistrar.ASH, "Ash")
+    }
+}

--- a/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Models.scala
+++ b/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/Models.scala
@@ -1,0 +1,28 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.ashwork.mc.multilingualexamples.registrar.ItemRegistrar
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricModelProvider
+import net.minecraft.data.models.model.ModelTemplates
+import net.minecraft.data.models.{BlockModelGenerators, ItemModelGenerators}
+
+/**
+ * A data provider which generates models for this mod.
+ *
+ * @param gen the generator being written to
+ */
+class Models(gen: FabricDataGenerator) extends FabricModelProvider(gen) {
+
+    override def generateBlockStateModels(generators: BlockModelGenerators): Unit = {}
+
+    override def generateItemModels(generators: ItemModelGenerators): Unit = {
+        // Simple item models through the 'item/generated' parent.
+        generators.generateFlatItem(ItemRegistrar.ASH, ModelTemplates.FLAT_ITEM)
+    }
+}

--- a/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.scala
+++ b/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/data/MultilingualExamplesData.scala
@@ -1,0 +1,24 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2022 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.data
+
+import net.fabricmc.fabric.api.datagen.v1.{DataGeneratorEntrypoint, FabricDataGenerator}
+
+/**
+ * A class instance used to run providers to generate files necessary by specified
+ * objects (e.g. models, localizations, etc.) The fully qualified name of this class
+ * must match that within 'entrypoints.fabric-datagen'. Any data entry point must
+ * implement [[DataGeneratorEntrypoint]].
+ */
+class MultilingualExamplesData extends DataGeneratorEntrypoint {
+
+    override def onInitializeDataGenerator(gen: FabricDataGenerator): Unit = {
+        // Add providers
+        gen.addProvider(new Localizations(_))
+        gen.addProvider(new Models(_))
+    }
+}


### PR DESCRIPTION
Adds support for data generators for fabric and quilt.

Quilt has support through the `quilted-fabric-api`, will need to be redone in the future.

Tasks
- [x] Working Concept
- [x] Documentation
- [x] Ported to Kotlin
- [x] Ported to Scala
- [x] Ported to Groovy
- [x] Ported to Quilt