### PR TITLE
[1.19.x] Implementing Quilt's Armor Rendering Registry

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ fabric_api = "0.81.1+1.19.4"
 
 # Latest Quilt Versions
 # https://lambdaurora.dev/tools/import_quilt.html
-quilt_loom = "1.+"
+quilt_loom = "1.1.+"
 quilt_loader = "0.19.0-beta.13"
 quilted_fabric_api = "6.0.0-beta.6+0.79.0-1.19.4"
 

--- a/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.groovy
+++ b/quilt/quilt-groovy/src/main/groovy/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.groovy
@@ -1,0 +1,146 @@
+package net.ashwork.mc.multilingualexamples.mixin
+
+import com.mojang.blaze3d.vertex.PoseStack
+import groovy.transform.CompileStatic
+import net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient
+import net.minecraft.client.model.HumanoidModel
+import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.client.renderer.RenderType
+import net.minecraft.client.renderer.entity.ItemRenderer
+import net.minecraft.client.renderer.entity.RenderLayerParent
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer
+import net.minecraft.client.renderer.entity.layers.RenderLayer
+import net.minecraft.client.renderer.texture.OverlayTexture
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.item.ArmorItem
+import org.jetbrains.annotations.Nullable
+import org.spongepowered.asm.mixin.Mixin
+import org.spongepowered.asm.mixin.Shadow
+import org.spongepowered.asm.mixin.Unique
+import org.spongepowered.asm.mixin.injection.At
+import org.spongepowered.asm.mixin.injection.Inject
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
+
+/**
+ * A mixin used to inject logic into {@link HumanoidArmorLayer}.
+ *
+ * <p>This is used in place of quilt's mixin as it does not allow general armor
+ * models to be rendered onto a humanoid parent model.
+ */
+@CompileStatic
+@Mixin(HumanoidArmorLayer.class)
+abstract class HumanoidArmorLayerMixin extends RenderLayer<LivingEntity, HumanoidModel<LivingEntity>> {
+
+    /**
+     * A private constructor, should never be called.
+     *
+     * @param parent the parent renderer
+     */
+    private HumanoidArmorLayerMixin(RenderLayerParent<LivingEntity, HumanoidModel<LivingEntity>> parent) {
+        super(parent)
+    }
+
+    @Shadow
+    private ResourceLocation getArmorLocation(ArmorItem item, boolean usesInnerModel, @Nullable String textureSuffix) {
+        throw new AssertionError("Method is shadowed from HumanoidArmorLayer!" as Object)
+    }
+
+    @Unique
+    private LivingEntity multilingualExamples$capturedEntity
+    @Unique
+    private EquipmentSlot multilingualExamples$capturedSlot
+
+    /**
+     * A method used to capture the entity the armor is being rendered for.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
+    private void multilingualExamples$captureEntity(PoseStack pose, MultiBufferSource source, int packedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+        this.multilingualExamples$capturedEntity = entity
+    }
+
+    /**
+     * A method used to capture the slot holding the armor being rendered.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param entity the entity the armor is rendered on
+     * @param slot the slot being rendered for the armor
+     * @param packedLight the compressed block and skylight values
+     * @param originalModel the original armor model to be rendered
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = @At("HEAD"), method = "renderArmorPiece")
+    private void multilingualExamples$captureSlot(PoseStack pose, MultiBufferSource source, LivingEntity entity, EquipmentSlot slot, int packedLight, HumanoidModel<? extends LivingEntity> originalModel, CallbackInfo ci) {
+        this.multilingualExamples$capturedSlot = slot
+    }
+
+    /**
+     * A method to release the captured data at the end of the rendering.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = @At("RETURN"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
+    private void multilingualExamples$release(PoseStack pose, MultiBufferSource source, int packedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+        this.multilingualExamples$capturedEntity = null
+        this.multilingualExamples$capturedSlot = null
+    }
+
+    /**
+     * A method to inject logic when attempting to render a model.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param item the armor item being rendered on the player
+     * @param hasFoil {@code true} when the armor has a foil-like effect, usually when enchanted
+     * @param originalModel the original armor model to be rendered
+     * @param useInnerModel {@code true} when the inner model, usually for leggings, should be used
+     * @param r a [0,1] value containing the red tint to apply
+     * @param g a [0,1] value containing the green tint to apply
+     * @param b a [0,1] value containing the blue tint to apply
+     * @param textureSuffix the suffix of the texture to apply to the armor model
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
+    private void renderArmor(PoseStack pose, MultiBufferSource source, int packedLight, ArmorItem item, boolean hasFoil, HumanoidModel<? extends LivingEntity> originalModel, boolean useInnerModel, float r, float g, float b, @Nullable String textureSuffix, CallbackInfo ci) {
+        // Check if a handler exists
+        if (MultilingualExamplesClient.instance().armorModelManager().hasHandler(item)) {
+            var handler = MultilingualExamplesClient.instance().armorModelManager().getHandler(item.material, this.multilingualExamples$capturedEntity)
+
+            // Get intermediary values
+            var stack = this.multilingualExamples$capturedEntity.getItemBySlot(this.multilingualExamples$capturedSlot)
+            var texture = handler.getArmorTexture(this.getArmorLocation(item, useInnerModel, textureSuffix), this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, useInnerModel, textureSuffix)
+            var renderType = handler.getArmorRenderLayer(RenderType.armorCutoutNoCull(texture), this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, texture)
+
+            // Render model and cancel event
+            var vbo = ItemRenderer.getArmorFoilBuffer(source, renderType, false, hasFoil)
+            handler.getAndSetup(this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, this.parentModel)
+                    .renderToBuffer(pose, vbo, packedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f)
+            ci.cancel()
+        }
+    }
+}

--- a/quilt/quilt-groovy/src/main/resources/multilingual_examples.mixins.json
+++ b/quilt/quilt-groovy/src/main/resources/multilingual_examples.mixins.json
@@ -5,7 +5,8 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-        "EntityRenderDispatcherMixin"
+        "EntityRenderDispatcherMixin",
+        "HumanoidArmorLayerMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.java
@@ -151,14 +151,12 @@ public class ArmorModelManager {
          */
 
         // Register the renderer used for the custom armor models for each supported armor item
-        ArmorRenderingRegistry.TextureProvider textureProvider = (texture, entity, stack, slot, useSecondLayer, suffix) -> {
-            var handler = this.getHandler(((ArmorItem) stack.getItem()).getMaterial(), entity);
-            return handler.getArmorTexture(texture, entity, stack, slot, useSecondLayer, suffix);
-        };
-        ArmorRenderingRegistry.RenderLayerProvider renderTypeProvider = (type, entity, stack, slot, texture) -> {
-            var handler = this.getHandler(((ArmorItem) stack.getItem()).getMaterial(), entity);
-            return handler.getArmorRenderLayer(type, entity, stack, slot, texture);
-        };
+        ArmorRenderingRegistry.TextureProvider textureProvider = (texture, entity, stack, slot, useSecondLayer, suffix) ->
+                this.getHandler(((ArmorItem) stack.getItem()).getMaterial(), entity)
+                        .getArmorTexture(texture, entity, stack, slot, useSecondLayer, suffix);
+        ArmorRenderingRegistry.RenderLayerProvider renderTypeProvider = (type, entity, stack, slot, texture) ->
+                this.getHandler(((ArmorItem) stack.getItem()).getMaterial(), entity)
+                        .getArmorRenderLayer(type, entity, stack, slot, texture);
         ItemRegistrar.registerRenderers(item -> {
             // Add armor item to list for model logic
             this.customArmorItems.add(item);

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.java
@@ -29,7 +29,6 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,7 +47,7 @@ public class ArmorModelManager {
 
     private final Table<EntityType<?>, ArmorMaterial, ModelHandler> entityArmorModels;
     private final Table<String, ArmorMaterial, ModelHandler> playerArmorModels;
-    private final Set<Item> customArmorItems;
+    private final Set<ArmorItem> customArmorItems;
 
     /**
      * Default constructor.

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.java
@@ -58,34 +58,79 @@ public abstract class HumanoidArmorLayerMixin extends RenderLayer<LivingEntity, 
 
     /**
      * A method used to capture the entity the armor is being rendered for.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
      */
     @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
-    private void multilingualExamples$captureEntity(PoseStack pose, MultiBufferSource source, int combinedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+    private void multilingualExamples$captureEntity(PoseStack pose, MultiBufferSource source, int packedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
         this.multilingualExamples$capturedEntity = entity;
     }
 
     /**
      * A method used to capture the slot holding the armor being rendered.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param entity the entity the armor is rendered on
+     * @param slot the slot being rendered for the armor
+     * @param packedLight the compressed block and skylight values
+     * @param originalModel the original armor model to be rendered
+     * @param ci a callback containing information about the injection
      */
     @Inject(at = @At("HEAD"), method = "renderArmorPiece")
-    private void multilingualExamples$captureSlot(PoseStack pose, MultiBufferSource source, LivingEntity entity, EquipmentSlot slot, int combinedLight, HumanoidModel<?> originalModel, CallbackInfo ci) {
+    private void multilingualExamples$captureSlot(PoseStack pose, MultiBufferSource source, LivingEntity entity, EquipmentSlot slot, int packedLight, HumanoidModel<?> originalModel, CallbackInfo ci) {
         this.multilingualExamples$capturedSlot = slot;
     }
 
     /**
      * A method to release the captured data at the end of the rendering.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
      */
     @Inject(at = @At("RETURN"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
-    private void multilingualExamples$release(PoseStack pose, MultiBufferSource source, int combinedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+    private void multilingualExamples$release(PoseStack pose, MultiBufferSource source, int packedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
         this.multilingualExamples$capturedEntity = null;
         this.multilingualExamples$capturedSlot = null;
     }
 
     /**
      * A method to inject logic when attempting to render a model.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param item the armor item being rendered on the player
+     * @param hasFoil {@code true} when the armor has a foil-like effect, usually when enchanted
+     * @param originalModel the original armor model to be rendered
+     * @param useInnerModel {@code true} when the inner model, usually for leggings, should be used
+     * @param r a [0,1] value containing the red tint to apply
+     * @param g a [0,1] value containing the green tint to apply
+     * @param b a [0,1] value containing the blue tint to apply
+     * @param textureSuffix the suffix of the texture to apply to the armor model
+     * @param ci a callback containing information about the injection
      */
     @Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
-    private void renderArmor(PoseStack pose, MultiBufferSource source, int combinedLight, ArmorItem item, boolean hasFoil, HumanoidModel<?> originalModel, boolean useInnerModel, float r, float g, float b, @Nullable String textureSuffix, CallbackInfo ci) {
+    private void renderArmor(PoseStack pose, MultiBufferSource source, int packedLight, ArmorItem item, boolean hasFoil, HumanoidModel<?> originalModel, boolean useInnerModel, float r, float g, float b, @Nullable String textureSuffix, CallbackInfo ci) {
         // Check if a handler exists
         if (MultilingualExamplesClient.instance().armorModelManager().hasHandler(item)) {
             var handler = MultilingualExamplesClient.instance().armorModelManager().getHandler(item.getMaterial(), this.multilingualExamples$capturedEntity);
@@ -98,7 +143,7 @@ public abstract class HumanoidArmorLayerMixin extends RenderLayer<LivingEntity, 
             // Render model and cancel event
             var vbo = ItemRenderer.getArmorFoilBuffer(source, renderType, false, hasFoil);
             handler.getAndSetup(this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, this.getParentModel())
-                    .renderToBuffer(pose, vbo, combinedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f);
+                    .renderToBuffer(pose, vbo, packedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f);
             ci.cancel();
         }
     }

--- a/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.java
+++ b/quilt/quilt-java/src/main/java/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.java
@@ -1,0 +1,105 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2023 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ArmorItem;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * A mixin used to inject logic into {@link HumanoidArmorLayer}.
+ *
+ * <p>This is used in place of quilt's mixin as it does not allow general armor
+ * models to be rendered onto a humanoid parent model.
+ */
+@Mixin(HumanoidArmorLayer.class)
+public abstract class HumanoidArmorLayerMixin extends RenderLayer<LivingEntity, HumanoidModel<LivingEntity>> {
+
+    /**
+     * A private constructor, should never be called.
+     *
+     * @param parent the parent renderer
+     */
+    private HumanoidArmorLayerMixin(RenderLayerParent<LivingEntity, HumanoidModel<LivingEntity>> parent) {
+        super(parent);
+    }
+
+    @Shadow
+    private ResourceLocation getArmorLocation(ArmorItem item, boolean usesInnerModel, @Nullable String textureSuffix) {
+        throw new AssertionError("Method is shadowed from HumanoidArmorLayer!");
+    }
+
+    @Unique
+    private LivingEntity multilingualExamples$capturedEntity;
+    @Unique
+    private EquipmentSlot multilingualExamples$capturedSlot;
+
+    /**
+     * A method used to capture the entity the armor is being rendered for.
+     */
+    @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
+    private void multilingualExamples$captureEntity(PoseStack pose, MultiBufferSource source, int combinedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+        this.multilingualExamples$capturedEntity = entity;
+    }
+
+    /**
+     * A method used to capture the slot holding the armor being rendered.
+     */
+    @Inject(at = @At("HEAD"), method = "renderArmorPiece")
+    private void multilingualExamples$captureSlot(PoseStack pose, MultiBufferSource source, LivingEntity entity, EquipmentSlot slot, int combinedLight, HumanoidModel<?> originalModel, CallbackInfo ci) {
+        this.multilingualExamples$capturedSlot = slot;
+    }
+
+    /**
+     * A method to release the captured data at the end of the rendering.
+     */
+    @Inject(at = @At("RETURN"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
+    private void multilingualExamples$release(PoseStack pose, MultiBufferSource source, int combinedLight, LivingEntity entity, float position, float speed, float partialTick, float bob, float yRot, float xRot, CallbackInfo ci) {
+        this.multilingualExamples$capturedEntity = null;
+        this.multilingualExamples$capturedSlot = null;
+    }
+
+    /**
+     * A method to inject logic when attempting to render a model.
+     */
+    @Inject(at = @At("HEAD"), method = "renderModel", cancellable = true)
+    private void renderArmor(PoseStack pose, MultiBufferSource source, int combinedLight, ArmorItem item, boolean hasFoil, HumanoidModel<?> originalModel, boolean useInnerModel, float r, float g, float b, @Nullable String textureSuffix, CallbackInfo ci) {
+        // Check if a handler exists
+        if (MultilingualExamplesClient.instance().armorModelManager().hasHandler(item)) {
+            var handler = MultilingualExamplesClient.instance().armorModelManager().getHandler(item.getMaterial(), this.multilingualExamples$capturedEntity);
+
+            // Get intermediary values
+            var stack = this.multilingualExamples$capturedEntity.getItemBySlot(this.multilingualExamples$capturedSlot);
+            var texture = handler.getArmorTexture(this.getArmorLocation(item, useInnerModel, textureSuffix), this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, useInnerModel, textureSuffix);
+            var renderType = handler.getArmorRenderLayer(RenderType.armorCutoutNoCull(texture), this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, texture);
+
+            // Render model and cancel event
+            var vbo = ItemRenderer.getArmorFoilBuffer(source, renderType, false, hasFoil);
+            handler.getAndSetup(this.multilingualExamples$capturedEntity, stack, this.multilingualExamples$capturedSlot, this.getParentModel())
+                    .renderToBuffer(pose, vbo, combinedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f);
+            ci.cancel();
+        }
+    }
+}

--- a/quilt/quilt-java/src/main/resources/multilingual_examples.mixins.json
+++ b/quilt/quilt-java/src/main/resources/multilingual_examples.mixins.json
@@ -5,7 +5,8 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-        "EntityRenderDispatcherMixin"
+        "EntityRenderDispatcherMixin",
+        "HumanoidArmorLayerMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.kt
@@ -118,12 +118,12 @@ class ArmorModelManager {
 
         // Register the renderer used for the custom armor models for each supported armor item
         val textureProvider = TextureProvider { texture, entity, stack, slot, useSecondLayer, suffix ->
-            val handler = this.getHandler((stack.item as ArmorItem).material, entity)
-            return@TextureProvider handler.getArmorTexture(texture, entity, stack, slot, useSecondLayer, suffix)
+            return@TextureProvider this.getHandler((stack.item as ArmorItem).material, entity)
+                .getArmorTexture(texture, entity, stack, slot, useSecondLayer, suffix)
         }
-        val renderTypeProvider = RenderLayerProvider { layer, entity, stack, slot, texture ->
-            val handler = this.getHandler((stack.item as ArmorItem).material, entity)
-            return@RenderLayerProvider handler.getArmorRenderLayer(layer, entity, stack, slot, texture)
+        val renderTypeProvider = RenderLayerProvider { type, entity, stack, slot, texture ->
+            return@RenderLayerProvider this.getHandler((stack.item as ArmorItem).material, entity)
+                .getArmorRenderLayer(type, entity, stack, slot, texture)
         }
         registerRenderers {
             // Add armor item to list for model logic

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/client/model/ArmorModelManager.kt
@@ -10,7 +10,6 @@ import com.google.common.collect.HashBasedTable
 import com.google.common.collect.Table
 import net.ashwork.mc.multilingualexamples.item.ExampleArmorMaterials
 import net.ashwork.mc.multilingualexamples.registrar.registerRenderers
-import net.fabricmc.fabric.api.client.rendering.v1.ArmorRenderer
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry
 import net.minecraft.client.model.HumanoidModel
 import net.minecraft.client.model.Model
@@ -20,6 +19,7 @@ import net.minecraft.client.model.geom.ModelPart
 import net.minecraft.client.model.geom.builders.CubeDeformation
 import net.minecraft.client.model.geom.builders.LayerDefinition
 import net.minecraft.client.player.AbstractClientPlayer
+import net.minecraft.client.renderer.RenderType
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.entity.Entity
@@ -29,6 +29,9 @@ import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.ArmorItem
 import net.minecraft.world.item.ArmorMaterial
 import net.minecraft.world.item.ItemStack
+import org.quiltmc.qsl.rendering.entity.api.client.ArmorRenderingRegistry
+import org.quiltmc.qsl.rendering.entity.api.client.ArmorRenderingRegistry.RenderLayerProvider
+import org.quiltmc.qsl.rendering.entity.api.client.ArmorRenderingRegistry.TextureProvider
 
 /**
  * A manager used for handling armor models on any given entity.
@@ -37,6 +40,7 @@ class ArmorModelManager {
 
     private val entityArmorModels: Table<EntityType<*>, ArmorMaterial, ModelHandler> = HashBasedTable.create()
     private val playerArmorModels: Table<String, ArmorMaterial, ModelHandler> = HashBasedTable.create()
+    private val customArmorItems: MutableSet<ArmorItem> = mutableSetOf()
 
     /**
      * Registers a single handler for an armor model for use with the
@@ -104,14 +108,31 @@ class ArmorModelManager {
      * A method used to initialize the custom armor model handlers.
      */
     fun init() {
+        /*
+        Quilt's armor rendering logic only encompasses humanoid models, which
+        limits the extension of this manager to handle any Model logic. As such,
+        while we register texture and RenderType providers, we don't make use
+        of them, opting instead to use our own mixin to handle the armor model
+        rendering.
+         */
+
         // Register the renderer used for the custom armor models for each supported armor item
-        val renderer = ArmorRenderer { poseStack, bufferSource, stack, entity, slot, light, context ->
-            if (stack.item is ArmorItem) {
-                val handler = this.getHandler((stack.item as ArmorItem).material, entity)
-                ArmorRenderer.renderPart(poseStack, bufferSource, light, stack, handler.getAndSetup(entity, stack, slot, context), handler.getTexture(stack, entity, slot))
-            }
+        val textureProvider = TextureProvider { texture, entity, stack, slot, useSecondLayer, suffix ->
+            val handler = this.getHandler((stack.item as ArmorItem).material, entity)
+            return@TextureProvider handler.getArmorTexture(texture, entity, stack, slot, useSecondLayer, suffix)
         }
-        registerRenderers { ArmorRenderer.register(renderer, it) }
+        val renderTypeProvider = RenderLayerProvider { layer, entity, stack, slot, texture ->
+            val handler = this.getHandler((stack.item as ArmorItem).material, entity)
+            return@RenderLayerProvider handler.getArmorRenderLayer(layer, entity, stack, slot, texture)
+        }
+        registerRenderers {
+            // Add armor item to list for model logic
+            this.customArmorItems += it
+
+            // Add providers
+            ArmorRenderingRegistry.registerTextureProvider(textureProvider, it)
+            ArmorRenderingRegistry.registerRenderLayerProvider(renderTypeProvider, it)
+        }
 
         /*
         This registers the definitions that allow us to create the models for
@@ -225,12 +246,20 @@ class ArmorModelManager {
      * @return the model handler
      * @throws NullPointerException if there is no default player armor model handler
      */
-    private fun getHandler(material: ArmorMaterial, entity: Entity): ModelHandler {
+    fun getHandler(material: ArmorMaterial, entity: Entity): ModelHandler {
         val handler = if (entity is AbstractClientPlayer) this.playerArmorModels.get(entity.modelName, material)
             else this.entityArmorModels.get(entity.type, material)
 
         return handler ?: this.playerArmorModels.get("default", material)!!
     }
+
+    /**
+     * Returns whether the item should use a custom armor model renderer.
+     *
+     * @param item the armor item being checked
+     * @return whether the item should use a custom armor model renderer
+     */
+    fun hasHandler(item: ArmorItem): Boolean = this.customArmorItems.contains(item)
 }
 
 /**
@@ -256,7 +285,7 @@ private inline fun <T: Model> createSingleModel(material: ArmorMaterial, crossin
 /**
  * A handler for managing models not attached to any entity renderer.
  */
-interface ModelHandler {
+interface ModelHandler: TextureProvider, RenderLayerProvider {
 
     /**
      * Constructs the model anytime the assets are reloaded.
@@ -276,16 +305,6 @@ interface ModelHandler {
      * @return the model to be rendered
      */
     fun getAndSetup(entity: LivingEntity, stack: ItemStack, slot: EquipmentSlot, context: HumanoidModel<*>): Model
-
-    /**
-     * Gets the texture to apply to the model.
-     *
-     * @param stack the armor currently being worn
-     * @param entity the entity wearing the armor
-     * @param slot the slot the armor is in
-     * @return the full path and extension of the texture
-     */
-    fun getTexture(stack: ItemStack, entity: Entity, slot: EquipmentSlot): ResourceLocation
 }
 
 /**
@@ -310,5 +329,7 @@ class SingleModelHandler<out T: Model>(private val texture: ResourceLocation, pr
         return this.model
     }
 
-    override fun getTexture(stack: ItemStack, entity: Entity, slot: EquipmentSlot): ResourceLocation = this.texture
+    override fun getArmorTexture(texture: ResourceLocation, entity: LivingEntity, stack: ItemStack, slot: EquipmentSlot, useSecondLayer: Boolean, suffix: String?): ResourceLocation = this.texture
+
+    override fun getArmorRenderLayer(layer: RenderType, entity: LivingEntity, stack: ItemStack, slot: EquipmentSlot, texture: ResourceLocation): RenderType = this.model.renderType(texture)
 }

--- a/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.kt
+++ b/quilt/quilt-kotlin/src/main/kotlin/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.kt
@@ -1,0 +1,145 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2023 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.mixin
+
+import com.mojang.blaze3d.vertex.PoseStack
+import net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient
+import net.minecraft.client.model.HumanoidModel
+import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.client.renderer.RenderType
+import net.minecraft.client.renderer.entity.ItemRenderer
+import net.minecraft.client.renderer.entity.RenderLayerParent
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer
+import net.minecraft.client.renderer.entity.layers.RenderLayer
+import net.minecraft.client.renderer.texture.OverlayTexture
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.entity.EquipmentSlot
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.item.ArmorItem
+import org.spongepowered.asm.mixin.Mixin
+import org.spongepowered.asm.mixin.Shadow
+import org.spongepowered.asm.mixin.Unique
+import org.spongepowered.asm.mixin.injection.At
+import org.spongepowered.asm.mixin.injection.Inject
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
+
+
+/**
+ * A mixin used to inject logic into [HumanoidArmorLayer].
+ *
+ * This is used in place of quilt's mixin as it does not allow general armor
+ * models to be rendered onto a humanoid parent model.
+ *
+ * @param parent the parent renderer
+ */
+@Mixin(HumanoidArmorLayer::class)
+abstract class HumanoidArmorLayerMixin private constructor(parent: RenderLayerParent<LivingEntity, HumanoidModel<LivingEntity>>) : RenderLayer<LivingEntity, HumanoidModel<LivingEntity>>(parent) {
+
+    @Shadow
+    private fun getArmorLocation(item: ArmorItem, usesInnerModel: Boolean, textureSuffix: String?): ResourceLocation =
+        throw AssertionError("Method is shadowed from HumanoidArmorLayer!")
+
+    @Unique
+    private var multilingualExamplesCapturedEntity: LivingEntity? = null
+
+    @Unique
+    private var multilingualExamplesCapturedSlot: EquipmentSlot? = null
+
+    /**
+     * A method used to capture the entity the armor is being rendered for.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = [At("HEAD")], method = ["render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V"])
+    private fun multilingualExamplesCaptureEntity(pose: PoseStack, source: MultiBufferSource, packedLight: Int, entity: LivingEntity, position: Float, speed: Float, partialTick: Float, bob: Float, yRot: Float, xRot: Float, ci: CallbackInfo) {
+        this.multilingualExamplesCapturedEntity = entity
+    }
+
+    /**
+     * A method used to capture the slot holding the armor being rendered.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param entity the entity the armor is rendered on
+     * @param slot the slot being rendered for the armor
+     * @param packedLight the compressed block and skylight values
+     * @param originalModel the original armor model to be rendered
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = [At("HEAD")], method = ["renderArmorPiece"])
+    private fun multilingualExamplesCaptureSlot(pose: PoseStack, source: MultiBufferSource, entity: LivingEntity, slot: EquipmentSlot, packedLight: Int, originalModel: HumanoidModel<*>, ci: CallbackInfo) {
+        this.multilingualExamplesCapturedSlot = slot
+    }
+
+    /**
+     * A method to release the captured data at the end of the rendering.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity the entity the armor is rendered on
+     * @param position the lerped position of the entity
+     * @param speed the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob the amount of bob on the head
+     * @param yRot the y rotation of the entity
+     * @param xRot the x rotation of the entity
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = [At("RETURN")], method = ["render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V"])
+    private fun multilingualExamplesRelease(pose: PoseStack, source: MultiBufferSource, packedLight: Int, entity: LivingEntity, position: Float, speed: Float, partialTick: Float, bob: Float, yRot: Float, xRot: Float, ci: CallbackInfo) {
+        this.multilingualExamplesCapturedEntity = null
+        this.multilingualExamplesCapturedSlot = null
+    }
+
+    /**
+     * A method to inject logic when attempting to render a model.
+     *
+     * @param pose the transformations to apply to the rendering object
+     * @param source the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param item the armor item being rendered on the player
+     * @param hasFoil {@code true} when the armor has a foil-like effect, usually when enchanted
+     * @param originalModel the original armor model to be rendered
+     * @param useInnerModel {@code true} when the inner model, usually for leggings, should be used
+     * @param r a [0,1] value containing the red tint to apply
+     * @param g a [0,1] value containing the green tint to apply
+     * @param b a [0,1] value containing the blue tint to apply
+     * @param textureSuffix the suffix of the texture to apply to the armor model
+     * @param ci a callback containing information about the injection
+     */
+    @Inject(at = [At("HEAD")], method = ["renderModel"], cancellable = true)
+    private fun renderArmor(pose: PoseStack, source: MultiBufferSource, packedLight: Int, item: ArmorItem, hasFoil: Boolean, originalModel: HumanoidModel<*>, useInnerModel: Boolean, r: Float, g: Float, b: Float, textureSuffix: String?, ci: CallbackInfo) {
+        // Check if a handler exists
+        if (MultilingualExamplesClient.armorModelManager().hasHandler(item)) {
+            val entity = this.multilingualExamplesCapturedEntity!!
+            val slot = this.multilingualExamplesCapturedSlot!!
+            val handler = MultilingualExamplesClient.armorModelManager().getHandler(item.material, entity)
+
+            // Get intermediary values
+            val stack = entity.getItemBySlot(slot)
+            val texture = handler.getArmorTexture(this.getArmorLocation(item, useInnerModel, textureSuffix), entity, stack, slot, useInnerModel, textureSuffix)
+            val renderType = handler.getArmorRenderLayer(RenderType.armorCutoutNoCull(texture), entity, stack, slot, texture)
+
+            // Render model and cancel event
+            val vbo = ItemRenderer.getArmorFoilBuffer(source, renderType, false, hasFoil)
+            handler.getAndSetup(entity, stack, slot, this.parentModel)
+                .renderToBuffer(pose, vbo, packedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f)
+            ci.cancel()
+        }
+    }
+}

--- a/quilt/quilt-kotlin/src/main/resources/multilingual_examples.mixins.json
+++ b/quilt/quilt-kotlin/src/main/resources/multilingual_examples.mixins.json
@@ -5,7 +5,8 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-        "EntityRenderDispatcherMixin"
+        "EntityRenderDispatcherMixin",
+        "HumanoidArmorLayerMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/quilt/quilt-scala/src/main/resources/multilingual_examples.mixins.json
+++ b/quilt/quilt-scala/src/main/resources/multilingual_examples.mixins.json
@@ -5,7 +5,8 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-        "EntityRenderDispatcherMixin"
+        "EntityRenderDispatcherMixin",
+        "HumanoidArmorLayerMixin"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.scala
+++ b/quilt/quilt-scala/src/main/scala/net/ashwork/mc/multilingualexamples/mixin/HumanoidArmorLayerMixin.scala
@@ -1,0 +1,119 @@
+/*
+ * Multilingual Examples
+ * Written 2021-2023 by ChampionAsh5357
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package net.ashwork.mc.multilingualexamples.mixin
+
+import com.mojang.blaze3d.vertex.PoseStack
+import net.ashwork.mc.multilingualexamples.client.MultilingualExamplesClient
+import net.minecraft.client.model.HumanoidModel
+import net.minecraft.client.renderer.{MultiBufferSource, RenderType}
+import net.minecraft.client.renderer.entity.{ItemRenderer, RenderLayerParent}
+import net.minecraft.client.renderer.entity.layers.{HumanoidArmorLayer, RenderLayer}
+import net.minecraft.client.renderer.texture.OverlayTexture
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.entity.{EquipmentSlot, LivingEntity}
+import net.minecraft.world.item.ArmorItem
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
+import org.spongepowered.asm.mixin.injection.{At, Inject}
+import org.spongepowered.asm.mixin.{Mixin, Shadow, Unique}
+
+/**
+ * A mixin used to inject logic into [[HumanoidArmorLayer]].
+ *
+ * This is used in place of quilt's mixin as it does not allow general armor
+ * models to be rendered onto a humanoid parent model.
+ *
+ * @param parent the parent renderer
+ */
+@Mixin(Array(classOf[HumanoidArmorLayer[_, _, _]]))
+abstract class HumanoidArmorLayerMixin private (parent: RenderLayerParent[LivingEntity, HumanoidModel[LivingEntity]]) extends RenderLayer[LivingEntity, HumanoidModel[LivingEntity]](parent) {
+
+    @Shadow
+    private def getArmorLocation(item: ArmorItem, usesInnerModel: Boolean, textureSuffix: String): ResourceLocation =
+        throw AssertionError("Method is shadowed from HumanoidArmorLayer!")
+
+    @Unique
+    private var multilingualExamplesCapturedEntity: Option[LivingEntity] = None
+
+    @Unique
+    private var multilingualExamplesCapturedSlot: Option[EquipmentSlot] = None
+
+    /**
+     * A method used to capture the entity the armor is being rendered for.
+     *
+     * @param pose        the transformations to apply to the rendering object
+     * @param source      the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity      the entity the armor is rendered on
+     * @param position    the lerped position of the entity
+     * @param speed       the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob         the amount of bob on the head
+     * @param yRot        the y rotation of the entity
+     * @param xRot        the x rotation of the entity
+     * @param ci          a callback containing information about the injection
+     */
+    @Inject(at = Array(At(value = "HEAD")), method = Array("render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V"))
+    private def multilingualExamplesCaptureEntity(pose: PoseStack, source: MultiBufferSource, packedLight: Int, entity: LivingEntity, position: Float, speed: Float, partialTick: Float, bob: Float, yRot: Float, xRot: Float, ci: CallbackInfo): Unit =
+        this.multilingualExamplesCapturedEntity = Some(entity)
+
+    /**
+     * A method used to capture the slot holding the armor being rendered.
+     *
+     * @param pose          the transformations to apply to the rendering object
+     * @param source        the vbo holder
+     * @param entity        the entity the armor is rendered on
+     * @param slot          the slot being rendered for the armor
+     * @param packedLight   the compressed block and skylight values
+     * @param originalModel the original armor model to be rendered
+     * @param ci            a callback containing information about the injection
+     */
+    @Inject(at = Array(At(value = "HEAD")), method = Array("renderArmorPiece"))
+    private def multilingualExamplesCaptureSlot(pose: PoseStack, source: MultiBufferSource, entity: LivingEntity, slot: EquipmentSlot, packedLight: Int, originalModel: HumanoidModel[_], ci: CallbackInfo): Unit =
+        this.multilingualExamplesCapturedSlot = Some(slot)
+
+    /**
+     * A method to release the captured data at the end of the rendering.
+     *
+     * @param pose        the transformations to apply to the rendering object
+     * @param source      the vbo holder
+     * @param packedLight the compressed block and skylight values
+     * @param entity      the entity the armor is rendered on
+     * @param position    the lerped position of the entity
+     * @param speed       the lerped speed of the entity
+     * @param partialTick the delta when the frame is rendered between ticks
+     * @param bob         the amount of bob on the head
+     * @param yRot        the y rotation of the entity
+     * @param xRot        the x rotation of the entity
+     * @param ci          a callback containing information about the injection
+     */
+    @Inject(at = Array(At(value = "RETURN")), method = Array("render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V"))
+    private def multilingualExamplesRelease(pose: PoseStack, source: MultiBufferSource, packedLight: Int, entity: LivingEntity, position: Float, speed: Float, partialTick: Float, bob: Float, yRot: Float, xRot: Float, ci: CallbackInfo): Unit = {
+        this.multilingualExamplesCapturedEntity = None
+        this.multilingualExamplesCapturedSlot = None
+    }
+
+    @Inject(at = Array(At(value = "HEAD")), method = Array("renderModel"), cancellable = true)
+    private def renderArmor(pose: PoseStack, source: MultiBufferSource, packedLight: Int, item: ArmorItem, hasFoil: Boolean, originalModel: HumanoidModel[_], useInnerModel: Boolean, r: Float, g: Float, b: Float, textureSuffix: String, ci: CallbackInfo): Unit = {
+        // Check if a handler exists
+        if (MultilingualExamplesClient.armorModelManager.hasHandler(item)) {
+            val entity = this.multilingualExamplesCapturedEntity.get
+            val slot = this.multilingualExamplesCapturedSlot.get
+            val handler = MultilingualExamplesClient.armorModelManager.getHandler(item.getMaterial, entity)
+
+            // Get intermediary values
+            val stack = entity.getItemBySlot(slot)
+            val texture = handler.getArmorTexture(this.getArmorLocation(item, useInnerModel, textureSuffix), entity, stack, slot, useInnerModel, textureSuffix)
+            val renderType = handler.getArmorRenderLayer(RenderType.armorCutoutNoCull(texture), entity, stack, slot, texture)
+
+            // Render model and cancel event
+            val vbo = ItemRenderer.getArmorFoilBuffer(source, renderType, false, hasFoil)
+            handler.getAndSetup(entity, stack, slot, this.getParentModel)
+                    .renderToBuffer(pose, vbo, packedLight, OverlayTexture.NO_OVERLAY, r, g, b, 1.0f)
+            ci.cancel()
+        }
+    }
+}


### PR DESCRIPTION
Updates the quilt branch to use their new `ArmorRenderingRegistry`. As their registry implementation does not accept arbitrary models, we currently need to implement our own mixin to handle the registry logic. As much logic as possible is delegated to their implementations.

- [x] Java
- [x] Kotlin
- [x] Scala
- [x] Groovy